### PR TITLE
Bulk operations support

### DIFF
--- a/arangodb-net-standard.Test/BulkOperationsApi/BulkOperationsApiClientTest.cs
+++ b/arangodb-net-standard.Test/BulkOperationsApi/BulkOperationsApiClientTest.cs
@@ -1,0 +1,109 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using ArangoDBNetStandard;
+using ArangoDBNetStandard.BulkOperationsApi;
+using ArangoDBNetStandard.BulkOperationsApi.Models;
+using ArangoDBNetStandard.Transport;
+using Moq;
+using Xunit;
+
+namespace ArangoDBNetStandardTest.BulkOperationsApi
+{
+    public class BulkOperationsApiClientTest : IClassFixture<BulkOperationsApiClientTestFixture>, IAsyncLifetime
+    {
+        private BulkOperationsApiClient _boApi;
+        private ArangoDBClient _adb;
+        private readonly string _testCollection;
+        private readonly ImportDocumentArraysBody _testImportDocumentArraysBody;
+        private readonly ImportDocumentObjectsBody _testImportDocumentObjectsBody;
+        private readonly string _testImportDocumentArraysJSON;
+        private readonly int _testImportDocumentArrayJSONCount;
+        private readonly string _testImportDocumentObjectsJSON;
+        private readonly int _testImportDocumentObjectJSONCount;
+        private readonly string _testImportDocumentObjectsType;
+
+        public BulkOperationsApiClientTest(BulkOperationsApiClientTestFixture fixture)
+        {
+            _adb = fixture.ArangoDBClient;
+            _boApi = _adb.BulkOperations;
+            _testCollection = fixture.TestCollectionName;
+            _testImportDocumentArraysBody = fixture.TestImportDocumentArraysBody;
+            _testImportDocumentObjectsBody = fixture.TestImportDocumentObjectsBody;
+            _testImportDocumentArraysJSON = fixture.TestImportDocumentArraysJSON;
+            _testImportDocumentObjectsJSON = fixture.TestImportDocumentObjectsJSON;
+            _testImportDocumentArrayJSONCount = fixture.TestImportDocumentArrayJSONCount;
+            _testImportDocumentObjectJSONCount = fixture.TestImportDocumentObjectJSONCount;
+            _testImportDocumentObjectsType = fixture.TestImportDocumentObjectsType;
+        }
+
+        public Task InitializeAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task DisposeAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        [Fact]
+        public async Task PostImportDocumentArraysAsync_ShouldSucceed()
+        {
+            var postResponse = await _boApi.PostImportDocumentArraysAsync(
+                new ImportDocumentsQuery()
+                {
+                    Collection = _testCollection
+                },
+                _testImportDocumentArraysBody);
+            Assert.False(postResponse.Error);
+            Assert.Equal(_testImportDocumentArraysBody.ValueArrays.Count(),
+                postResponse.Created);
+        }
+
+        [Fact]
+        public async Task PostImportDocumentJSONArraysAsync_ShouldSucceed()
+        {
+            var postResponse = await _boApi.PostImportDocumentArraysAsync(
+                new ImportDocumentsQuery()
+                {
+                    Collection = _testCollection,
+                },
+                _testImportDocumentArraysJSON);
+            Assert.False(postResponse.Error);
+            Assert.Equal(_testImportDocumentArrayJSONCount,
+                postResponse.Created);
+        }
+
+        [Fact]
+        public async Task PostImportDocumentObjectsAsync_ShouldSucceed()
+        {
+            var postResponse = await _boApi.PostImportDocumentObjectsAsync(
+                new ImportDocumentsQuery()
+                {
+                    Collection = _testCollection,
+                    Type = _testImportDocumentObjectsType
+                },
+                _testImportDocumentObjectsBody);
+            Assert.False(postResponse.Error);
+            Assert.Equal(_testImportDocumentObjectsBody.Documents.Count(),
+                postResponse.Created);
+        }
+
+        [Fact]
+        public async Task PostImportDocumentJSONObjectsAsync_ShouldSucceed()
+        {
+            var postResponse = await _boApi.PostImportDocumentObjectsAsync(
+                new ImportDocumentsQuery()
+                {
+                    Collection = _testCollection,
+                    Type = _testImportDocumentObjectsType
+                },
+                _testImportDocumentObjectsJSON);
+            Assert.False(postResponse.Error);
+            Assert.Equal(_testImportDocumentObjectJSONCount,
+                postResponse.Created);
+        }
+    }
+}

--- a/arangodb-net-standard.Test/BulkOperationsApi/BulkOperationsApiClientTestFixture.cs
+++ b/arangodb-net-standard.Test/BulkOperationsApi/BulkOperationsApiClientTestFixture.cs
@@ -1,0 +1,92 @@
+﻿using ArangoDBNetStandard;
+using ArangoDBNetStandard.CollectionApi.Models;
+using ArangoDBNetStandard.BulkOperationsApi.Models;
+using System;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+
+namespace ArangoDBNetStandardTest.BulkOperationsApi
+{
+    public class BulkOperationsApiClientTestFixture : ApiClientTestFixtureBase
+    {
+        public ArangoDBClient ArangoDBClient { get; internal set; }
+        public string TestCollectionName { get; internal set; } = "OurBulkTestCollection";
+        public ImportDocumentArraysBody TestImportDocumentArraysBody { get; internal set; }
+        public ImportDocumentObjectsBody TestImportDocumentObjectsBody { get; internal set; }
+        public string TestImportDocumentArraysJSON { get; internal set; }
+        public string TestImportDocumentObjectsJSON { get; internal set; }
+        public int TestImportDocumentArrayJSONCount { get; internal set; }
+        public int TestImportDocumentObjectJSONCount { get; internal set; }
+        public string TestImportDocumentObjectsType { get; internal set; }
+
+        public BulkOperationsApiClientTestFixture()
+        {
+        }
+
+        public override async Task InitializeAsync()
+        {
+            await base.InitializeAsync();
+            string dbName = nameof(BulkOperationsApiClientTestFixture);
+            await CreateDatabase(dbName);
+            Console.WriteLine("Database " + dbName + " created successfully");
+            ArangoDBClient = GetArangoDBClient(dbName);
+            try
+            {
+                var dbRes = await ArangoDBClient.Database.GetCurrentDatabaseInfoAsync();
+                if (dbRes.Error)
+                    throw new Exception("GetCurrentDatabaseInfoAsync failed: " + dbRes.Code.ToString());
+                else
+                {
+                    Console.WriteLine("In database " + dbRes.Result.Name);
+                    var colRes = await ArangoDBClient.Collection.PostCollectionAsync(new PostCollectionBody() { Name = TestCollectionName });
+                    if (colRes.Error)
+                        throw new Exception("PostCollectionAsync failed: " + colRes.Code.ToString());
+                    else
+                    {
+                        Console.WriteLine("Collection " + TestCollectionName + " created successfully");
+                        
+                        TestImportDocumentArraysBody = new ImportDocumentArraysBody()
+                        {
+                            DocumentAttributes = new List<string> { "name", "gender", "age" },
+                            ValueArrays = new List<object[]>
+                            {
+                                new object[] { "James", "M", "21" },
+                                new object[] { "Jack", "M", "23" },
+                                new object[] { "Jim", "M", "32" },
+                            }
+                        };
+                        TestImportDocumentArraysJSON = "[\"name\",\"gender\",\"age\"]" + Environment.NewLine +
+                                                        "[\"Craig\",\"M\",\"23\"]" + Environment.NewLine +
+                                                        "[\"Kurt\",\"M\",\"33\"]" + Environment.NewLine +
+                                                        "[\"Kevin\",\"M\",\"44\"]";
+                        TestImportDocumentArrayJSONCount = 3;
+
+
+                        TestImportDocumentObjectsBody = new ImportDocumentObjectsBody()
+                        {
+                             Documents = new List<object>()
+                             {
+                                 new { name = "Alfredine", gender = "F", age = "43" },
+                                 new { name = "Ronia", gender = "F", age = "36" },
+                                 new { name = "Jeremy", gender = "M", age = "33" },
+                             }
+                        };
+                        TestImportDocumentObjectsType = "documents";
+                        TestImportDocumentObjectsJSON = "{ name=\"Josy\", gender=\"F\", age =\"43\" }" + Environment.NewLine +
+                                                        "{ name=\"Marie\", gender=\"F\", age =\"34\" }" + Environment.NewLine +
+                                                        "{ name=\"Carinne\", gender=\"F\", age =\"53\" }" + Environment.NewLine;
+                        TestImportDocumentObjectJSONCount = 3;
+
+                        Console.WriteLine("Test data created successfully");
+                    }
+                }
+            }
+            catch (ApiErrorException ex) 
+            {
+                Console.WriteLine(ex.Message);
+                throw ex;
+            }
+
+        }
+    }
+}

--- a/arangodb-net-standard/ApiClientBase.cs
+++ b/arangodb-net-standard/ApiClientBase.cs
@@ -77,5 +77,18 @@ namespace ArangoDBNetStandard
                 throw new SerializationException($"A serialization error occured while preparing a request for Arango. See InnerException for more details.", e);
             }
         }
+
+        protected string GetContentString<T>(T item, ApiClientSerializationOptions serializationOptions)
+        {
+            try
+            {
+                return _serialization.SerializeToString(item, serializationOptions);
+            }
+            catch (Exception e)
+            {
+                throw new SerializationException($"A serialization error occured while preparing a request for Arango. See InnerException for more details.", e);
+            }
+        }
+
     }
 }

--- a/arangodb-net-standard/ArangoDBClient.cs
+++ b/arangodb-net-standard/ArangoDBClient.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net.Http;
 using ArangoDBNetStandard.AqlFunctionApi;
 using ArangoDBNetStandard.AuthApi;
+using ArangoDBNetStandard.BulkOperationsApi;
 using ArangoDBNetStandard.CollectionApi;
 using ArangoDBNetStandard.CursorApi;
 using ArangoDBNetStandard.DatabaseApi;
@@ -76,6 +77,11 @@ namespace ArangoDBNetStandard
         public IndexApiClient Index { get; private set; }
 
         /// <summary>
+        /// Bulk Operations API.
+        /// </summary>
+        public BulkOperationsApiClient BulkOperations { get; private set; }
+
+        /// <summary>
         /// Create an instance of <see cref="ArangoDBClient"/> from an existing
         /// <see cref="HttpClient"/> instance, using the default JSON serialization.
         /// </summary>
@@ -138,6 +144,7 @@ namespace ArangoDBNetStandard
             Graph = new GraphApiClient(transport, serialization);
             User = new UserApiClient(transport, serialization);
             Index = new IndexApiClient(transport, serialization);
+            BulkOperations = new BulkOperationsApiClient(transport, serialization);
         }
     }
 }

--- a/arangodb-net-standard/BulkOperationsApi/BulkOperationsApiClient.cs
+++ b/arangodb-net-standard/BulkOperationsApi/BulkOperationsApiClient.cs
@@ -117,7 +117,7 @@ namespace ArangoDBNetStandard.BulkOperationsApi
                 throw new ArgumentException("Collection name is required", nameof(query.Collection));
             }
 
-            if (string.IsNullOrEmpty(query.Collection))
+            if (string.IsNullOrEmpty(jsonBody))
             {
                 throw new ArgumentException("jsonBody is required", nameof(jsonBody));
             }
@@ -197,7 +197,7 @@ namespace ArangoDBNetStandard.BulkOperationsApi
                 throw new ArgumentException("Type is required", nameof(query.Type));
             }
 
-            if (string.IsNullOrEmpty(query.Collection))
+            if (string.IsNullOrEmpty(jsonBody))
             {
                 throw new ArgumentException("jsonBody is required", nameof(jsonBody));
             }

--- a/arangodb-net-standard/BulkOperationsApi/BulkOperationsApiClient.cs
+++ b/arangodb-net-standard/BulkOperationsApi/BulkOperationsApiClient.cs
@@ -1,0 +1,70 @@
+﻿using ArangoDBNetStandard.BulkOperationsApi.Models;
+using ArangoDBNetStandard.Serialization;
+using ArangoDBNetStandard.Transport;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ArangoDBNetStandard.BulkOperationsApi
+{
+    /// <summary>
+    /// A client for interacting with ArangoDB Bulk Operations API endpoints,
+    /// implementing <see cref="IBulkOperationsApiClient"/>.
+    /// </summary>
+    public class BulkOperationsApiClient:ApiClientBase, IBulkOperationsApiClient
+    {
+        /// <summary>
+        /// The transport client used to communicate with the ArangoDB host.
+        /// </summary>
+        protected IApiClientTransport _transport;
+
+        /// <summary>
+        /// The root path of the API.
+        /// </summary>
+        protected string _collectionApiPath = "_api/collection";
+
+        /// <summary>
+        /// Creates an instance of <see cref="BulkOperationsApiClient"/>
+        /// using the provided transport layer and the default JSON serialization.
+        /// </summary>
+        /// <param name="transport"></param>
+        public BulkOperationsApiClient(IApiClientTransport transport)
+            : base(new JsonNetApiClientSerialization())
+        {
+            _transport = transport;
+        }
+
+        /// <summary>
+        /// Creates an instance of <see cref="BulkOperationsApiClient"/>
+        /// using the provided transport and serialization layers.
+        /// </summary>
+        /// <param name="transport"></param>
+        /// <param name="serializer"></param>
+        public BulkOperationsApiClient(IApiClientTransport transport, IApiClientSerialization serializer)
+            : base(serializer)
+        {
+            _transport = transport;
+        }
+
+        public virtual async Task<ImportDocumentsResponse> PostImportDocumentArraysAsync(ImportDocumentsQuery query, ImportDocumentArraysBody body)
+        {
+            throw new NotImplementedException();
+        }
+
+        public virtual async Task<ImportDocumentsResponse> PostImportDocumentArraysAsync(ImportDocumentsQuery query, string body)
+        {
+            throw new NotImplementedException();
+        }
+
+        public virtual async Task<ImportDocumentsResponse> PostImportDocumentObjectsAsync(ImportDocumentsQuery query, ImportDocumentObjectsBody body)
+        {
+            throw new NotImplementedException();
+        }
+
+        public virtual async Task<ImportDocumentsResponse> PostImportDocumentObjectsAsync(ImportDocumentsQuery query, string body)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/arangodb-net-standard/BulkOperationsApi/BulkOperationsApiClient.cs
+++ b/arangodb-net-standard/BulkOperationsApi/BulkOperationsApiClient.cs
@@ -3,6 +3,7 @@ using ArangoDBNetStandard.Serialization;
 using ArangoDBNetStandard.Transport;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -22,7 +23,7 @@ namespace ArangoDBNetStandard.BulkOperationsApi
         /// <summary>
         /// The root path of the API.
         /// </summary>
-        protected string _collectionApiPath = "_api/collection";
+        protected string _bulkOperationsApiPath = "_api/import";
 
         /// <summary>
         /// Creates an instance of <see cref="BulkOperationsApiClient"/>
@@ -47,24 +48,177 @@ namespace ArangoDBNetStandard.BulkOperationsApi
             _transport = transport;
         }
 
-        public virtual async Task<ImportDocumentsResponse> PostImportDocumentArraysAsync(ImportDocumentsQuery query, ImportDocumentArraysBody body)
+        /// <summary>
+        /// Imports data arrays as documents into a collection.
+        /// POST /_api/import
+        /// </summary>
+        /// <param name="query">Options for the import.</param>
+        /// <param name="body">The body of the request containing required properties.</param>
+        /// <returns></returns>
+        public virtual async Task<ImportDocumentsResponse> PostImportDocumentArraysAsync(
+            ImportDocumentsQuery query,
+            ImportDocumentArraysBody body)
         {
-            throw new NotImplementedException();
+            if (body == null)
+            {
+                throw new ArgumentException("body is required", nameof(body));
+            }
+            else
+            {
+                if (body.DocumentAttributes == null || body.DocumentAttributes.Count() < 1)
+                {
+                    throw new ArgumentException("DocumentAttributes is required", nameof(body.DocumentAttributes));
+                }
+
+                if (body.ValueArrays == null || body.DocumentAttributes.Count() < 1)
+                {
+                    throw new ArgumentException("ValueArrays is required", nameof(body.ValueArrays));
+                }
+                else
+                {
+                    var maxValueLength = (from l in body.ValueArrays
+                                          where l != null
+                                          select l.Count()).Max();
+                    if (maxValueLength != body.DocumentAttributes.Count())
+                    {
+                        throw new ArgumentException(
+                            "Every array in ValueArrays must have the exact number of elements as the DocumentAttributes array.",
+                            nameof(body.ValueArrays));
+                    }
+                }
+            }
+            var contentString = string.Empty;
+            var options = new ApiClientSerializationOptions(true, true);
+            foreach (var valueArr in body.ValueArrays)
+            {
+                contentString += GetContentString(valueArr, options) + Environment.NewLine;
+            }
+            return await PostImportDocumentArraysAsync(query, contentString);
         }
 
-        public virtual async Task<ImportDocumentsResponse> PostImportDocumentArraysAsync(ImportDocumentsQuery query, string body)
+        /// <summary>
+        /// Imports data arrays as documents into a collection.
+        /// POST /_api/import
+        /// </summary>
+        /// <param name="query">Options for the import.</param>
+        /// <param name="jsonBody">The body of the request containing required value arrays.</param>
+        /// <returns></returns>
+        public virtual async Task<ImportDocumentsResponse> PostImportDocumentArraysAsync(
+            ImportDocumentsQuery query,
+            string jsonBody)
         {
-            throw new NotImplementedException();
+            if (query == null)
+            {
+                throw new ArgumentException("query is required", nameof(query));
+            }
+
+            if (string.IsNullOrEmpty(query.Collection))
+            {
+                throw new ArgumentException("Collection name is required", nameof(query.Collection));
+            }
+
+            if (string.IsNullOrEmpty(query.Collection))
+            {
+                throw new ArgumentException("jsonBody is required", nameof(jsonBody));
+            }
+
+            string uriString = _bulkOperationsApiPath;
+            uriString += "?" + query.ToQueryString();
+            var content = Encoding.UTF8.GetBytes(jsonBody);
+            using (var response = await _transport.PostAsync(uriString, content).ConfigureAwait(false))
+            {
+                var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                if (response.IsSuccessStatusCode)
+                {
+                    return DeserializeJsonFromStream<ImportDocumentsResponse>(stream);
+                }
+                throw await GetApiErrorException(response).ConfigureAwait(false);
+            }
         }
 
-        public virtual async Task<ImportDocumentsResponse> PostImportDocumentObjectsAsync(ImportDocumentsQuery query, ImportDocumentObjectsBody body)
+        public virtual async Task<ImportDocumentsResponse> PostImportDocumentObjectsAsync(
+            ImportDocumentsQuery query, 
+            ImportDocumentObjectsBody body)
         {
-            throw new NotImplementedException();
+            if (query == null)
+            {
+                throw new ArgumentException("query is required", nameof(query));
+            }
+
+            if (string.IsNullOrEmpty(query.Type))
+            {
+                throw new ArgumentException("Type is required", nameof(query.Type));
+            }
+
+            if (body == null)
+            {
+                throw new ArgumentException("body is required", nameof(body));
+            }
+            else if (body.Documents == null || body.Documents.Count() < 1)
+            {
+                throw new ArgumentException("Documents is required", nameof(body.Documents));
+            }
+
+            var contentString = string.Empty;
+            var options = new ApiClientSerializationOptions(true, true);
+
+            if (query.Type == "documents")
+            {
+                //body should be a list of documents seperated by newline char
+                foreach (var doc in body.Documents)
+                {
+                    contentString += GetContentString(doc, options) + Environment.NewLine;
+                }
+            }
+            else
+            {
+                //body should be one array of JSON objects
+                contentString = GetContentString(body.Documents, options);
+            }
+            return await PostImportDocumentObjectsAsync(query, contentString);
         }
 
-        public virtual async Task<ImportDocumentsResponse> PostImportDocumentObjectsAsync(ImportDocumentsQuery query, string body)
+        public virtual async Task<ImportDocumentsResponse> PostImportDocumentObjectsAsync(
+            ImportDocumentsQuery query,
+            string jsonBody)
         {
-            throw new NotImplementedException();
+            if (query == null)
+            {
+                throw new ArgumentException("query is required", nameof(query));
+            }
+
+            if (string.IsNullOrEmpty(query.Collection))
+            {
+                throw new ArgumentException("Collection name is required", nameof(query.Collection));
+            }
+
+            if (string.IsNullOrEmpty(query.Type))
+            {
+                throw new ArgumentException("Type is required", nameof(query.Type));
+            }
+
+            if (string.IsNullOrEmpty(query.Collection))
+            {
+                throw new ArgumentException("jsonBody is required", nameof(jsonBody));
+            }
+
+            string uriString = _bulkOperationsApiPath;
+            uriString += "?" + query.ToQueryString();
+            var content = Encoding.UTF8.GetBytes(jsonBody);
+            using (var response = await _transport.PostAsync(uriString, content).ConfigureAwait(false))
+            {
+                var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                if (response.IsSuccessStatusCode)
+                {
+                    return DeserializeJsonFromStream<ImportDocumentsResponse>(stream);
+                }
+                throw await GetApiErrorException(response).ConfigureAwait(false);
+            }
         }
+
+
+
+
+
     }
 }

--- a/arangodb-net-standard/BulkOperationsApi/IBulkOperationsApiClient.cs
+++ b/arangodb-net-standard/BulkOperationsApi/IBulkOperationsApiClient.cs
@@ -1,0 +1,60 @@
+﻿using ArangoDBNetStandard.BulkOperationsApi.Models;
+using System.Threading.Tasks;
+
+namespace ArangoDBNetStandard.BulkOperationsApi
+{
+    /// <summary>
+    /// Defines a client to access the ArangoDB API for
+    /// Bulk Operations
+    /// </summary>
+    public interface IBulkOperationsApiClient
+    {
+        /// <summary>
+        /// Imports data arrays as documents into a collection.
+        /// POST /_api/import
+        /// </summary>
+        /// <param name="query">Options for the import.</param>
+        /// <param name="body">The body of the request containing required properties.</param>
+        /// <returns></returns>
+        Task<ImportDocumentsResponse> PostImportDocumentArraysAsync(
+            ImportDocumentsQuery query,
+            ImportDocumentArraysBody body);
+
+        /// <summary>
+        /// Imports data arrays as documents into a collection.
+        /// POST /_api/import
+        /// </summary>
+        /// <param name="query">Options for the import.</param>
+        /// <param name="body">The body of the request containing required properties.</param>
+        /// <returns></returns>
+        Task<ImportDocumentsResponse> PostImportDocumentArraysAsync(
+            ImportDocumentsQuery query,
+            string body);
+
+        /// <summary>
+        /// Imports data arrays as documents into a collection.
+        /// Use this method if you have already structured the
+        /// JSON body according to the specifications.
+        /// POST /_api/import
+        /// </summary>
+        /// <param name="query">Options for the import.</param>
+        /// <param name="body">The body of the request containing required properties.</param>
+        /// <returns></returns>
+        Task<ImportDocumentsResponse> PostImportDocumentObjectsAsync(
+            ImportDocumentsQuery query,
+            ImportDocumentObjectsBody body);
+
+        /// <summary>
+        /// Imports data arrays as documents into a collection.
+        /// Use this method if you have already structured the
+        /// JSON body according to the specifications.
+        /// POST /_api/import
+        /// </summary>
+        /// <param name="query">Options for the import.</param>
+        /// <param name="body">The body of the request containing required properties.</param>
+        /// <returns></returns>
+        Task<ImportDocumentsResponse> PostImportDocumentObjectsAsync(
+            ImportDocumentsQuery query,
+            string body);
+    }
+}

--- a/arangodb-net-standard/BulkOperationsApi/IBulkOperationsApiClient.cs
+++ b/arangodb-net-standard/BulkOperationsApi/IBulkOperationsApiClient.cs
@@ -22,39 +22,40 @@ namespace ArangoDBNetStandard.BulkOperationsApi
 
         /// <summary>
         /// Imports data arrays as documents into a collection.
-        /// POST /_api/import
-        /// </summary>
-        /// <param name="query">Options for the import.</param>
-        /// <param name="body">The body of the request containing required properties.</param>
-        /// <returns></returns>
-        Task<ImportDocumentsResponse> PostImportDocumentArraysAsync(
-            ImportDocumentsQuery query,
-            string body);
-
-        /// <summary>
-        /// Imports data arrays as documents into a collection.
         /// Use this method if you have already structured the
         /// JSON body according to the specifications.
         /// POST /_api/import
         /// </summary>
         /// <param name="query">Options for the import.</param>
-        /// <param name="body">The body of the request containing required properties.</param>
+        /// <param name="jsonBody">The body of the request containing required value arrays.</param>
+        /// <returns></returns>
+        Task<ImportDocumentsResponse> PostImportDocumentArraysAsync(
+            ImportDocumentsQuery query,
+            string jsonBody);
+
+
+        /// <summary>
+        /// Imports objects as documents into a collection.
+        /// POST /_api/import
+        /// </summary>
+        /// <param name="query">Options for the import.</param>
+        /// <param name="body">The body of the request containing required objects.</param>
         /// <returns></returns>
         Task<ImportDocumentsResponse> PostImportDocumentObjectsAsync(
             ImportDocumentsQuery query,
             ImportDocumentObjectsBody body);
 
         /// <summary>
-        /// Imports data arrays as documents into a collection.
+        /// Imports objects as documents into a collection.
         /// Use this method if you have already structured the
         /// JSON body according to the specifications.
         /// POST /_api/import
         /// </summary>
         /// <param name="query">Options for the import.</param>
-        /// <param name="body">The body of the request containing required properties.</param>
+        /// <param name="jsonBody">The body of the request containing the required JSON objects.</param>
         /// <returns></returns>
         Task<ImportDocumentsResponse> PostImportDocumentObjectsAsync(
             ImportDocumentsQuery query,
-            string body);
+            string jsonBody);
     }
 }

--- a/arangodb-net-standard/BulkOperationsApi/Models/ImportDocumentArraysBody.cs
+++ b/arangodb-net-standard/BulkOperationsApi/Models/ImportDocumentArraysBody.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace ArangoDBNetStandard.BulkOperationsApi.Models
+{
+    /// <summary>
+    /// Represents a request body to Import documents as JSON-encoded lists
+    /// </summary>
+    public class ImportDocumentArraysBody
+    {
+        /// <summary>
+        /// List containing document attributes that are
+        /// being imported.
+        /// </summary>
+        public IEnumerable<string> DocumentAttributes { get; set; }
+
+        /// <summary>
+        /// List containing value arrays to be imported.
+        /// Each array is a document. Attribute values will 
+        /// be mapped to the attribute names by positions
+        /// defined in <see cref="DocumentAttributes"/> .
+        /// </summary>
+        public IEnumerable<IEnumerable<object>> ValueArrays { get; set; }
+    }
+
+}

--- a/arangodb-net-standard/BulkOperationsApi/Models/ImportDocumentObjectsBody.cs
+++ b/arangodb-net-standard/BulkOperationsApi/Models/ImportDocumentObjectsBody.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+
+namespace ArangoDBNetStandard.BulkOperationsApi.Models
+{
+    /// <summary>
+    /// Represents a request body to Import documents from an array of objects
+    /// </summary>
+    public class ImportDocumentObjectsBody
+    {
+        /// <summary>
+        /// List of document objects to import.
+        /// </summary>
+        public IEnumerable<object> Documents { get; set; }
+    }
+
+}

--- a/arangodb-net-standard/BulkOperationsApi/Models/ImportDocumentsOnDuplicate.cs
+++ b/arangodb-net-standard/BulkOperationsApi/Models/ImportDocumentsOnDuplicate.cs
@@ -1,0 +1,39 @@
+﻿namespace ArangoDBNetStandard.BulkOperationsApi.Models
+{
+    /// <summary>
+    /// Enum representing possible actions to carry out
+    /// in case of a unique key constraint violation.
+    /// </summary>
+    public enum ImportDocumentsOnDuplicate
+    {
+        /// <summary>
+        /// Will not import the current document 
+        /// because of the unique key constraint
+        /// violation. This is the default setting.
+        /// </summary>
+        Error,
+
+        /// <summary>
+        /// Will update an existing document in the 
+        /// database with the data specified in the
+        /// request. Attributes of the existing 
+        /// document that are not present in the 
+        /// request will be preserved.
+        /// </summary>
+        Update,
+
+        /// <summary>
+        /// Will replace an existing document in the 
+        /// database with the data specified in the
+        /// request.
+        /// </summary>
+        Replace,
+
+        /// <summary>
+        /// Will not update an existing document and 
+        /// simply ignore the error caused by the 
+        /// unique key constraint violation.
+        /// </summary>
+        Ignore
+    }
+}

--- a/arangodb-net-standard/BulkOperationsApi/Models/ImportDocumentsQuery.cs
+++ b/arangodb-net-standard/BulkOperationsApi/Models/ImportDocumentsQuery.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+
+namespace ArangoDBNetStandard.BulkOperationsApi.Models
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class ImportDocumentsQuery
+    {
+        /// <summary>
+        /// Required. Used to specify the target 
+        /// collection for the import. Importing 
+        /// data into a non-existing collection 
+        /// will produce an error.
+        /// </summary>
+        public string Collection { get; set; }
+
+        /// <summary>
+        /// Required for <see cref="BulkOperationsApiClient.PostImportDocumentObjectsAsync(ImportDocumentsQuery, ImportDocumentObjectsBody)"/>
+        /// Determines how the body of the request will be interpreted.
+        /// Type can have the following values:
+        /// 1) documents: When this type is used, each line in 
+        /// the request body is expected to be an individual 
+        /// JSON-encoded document. Multiple JSON objects in the 
+        /// request body need to be separated by newlines.
+        /// 2) list: When this type is used, the request body 
+        /// must contain a single JSON-encoded array of
+        /// individual objects to import.
+        /// 3) auto: if set, this will automatically
+        /// determine the body type
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Optional. Can be set to true to make the import 
+        /// only return if all documents have 
+        /// been synced to disk.
+        /// </summary>
+        public bool? WaitForSync { get; set; }
+
+        /// <summary>
+        /// Optional. The complete query parameter can be set
+        /// to true to make the entire import fail if 
+        /// any of the uploaded documents is invalid 
+        /// and cannot be imported. In this case, no 
+        /// documents will be imported by the import run,
+        /// even if a failure happens at the end of the import.
+        /// If complete has a value other than true, 
+        /// valid documents will be imported while invalid
+        /// documents will be rejected, meaning only 
+        /// some of the uploaded documents might have 
+        /// been imported.
+        /// </summary>
+        public bool? Complete { get; set; }
+
+        /// <summary>
+        /// Optional. The details query parameter can be set 
+        /// to true to make the import API return 
+        /// details about documents that could not
+        /// be imported. If details is true, then 
+        /// the result will also contain a details
+        /// attribute which is an array of detailed 
+        /// error messages. If the details is set 
+        /// to false or omitted, no details will 
+        /// be returned.
+        /// </summary>
+        public bool? Details { get; set; }
+
+        /// <summary>
+        /// Optional. An optional prefix for the values
+        /// in _from attributes. If specified, the value 
+        /// is automatically prepended to each _from input
+        /// value. This allows specifying just the keys 
+        /// for _from.
+        /// </summary>
+        public string FromPrefix { get; set; }
+
+        /// <summary>
+        /// Optional. An optional prefix for the values 
+        /// in _to attributes. If specified, the value is
+        /// automatically prepended to each _to input value.
+        /// This allows specifying just the keys for _to.
+        /// </summary>
+        public string ToPrefix { get; set; }
+
+        /// <summary>
+        /// If this parameter has a value of true or yes, 
+        /// then all data in the collection will be removed
+        /// prior to the import. Note that any existing 
+        /// index definitions will be preserved.
+        /// </summary>
+        public bool? Overwrite { get; set; }
+
+        /// <summary>
+        /// Controls what action is carried out in case 
+        /// of a unique key constraint violation.
+        /// </summary>
+        public ImportDocumentsOnDuplicate? OnDuplicate { get; set; }
+
+        /// <summary>
+        /// Generates the actual query string
+        /// </summary>
+        /// <returns></returns>
+        internal string ToQueryString()
+        {
+            List<string> query = new List<string>();
+            if (Collection != null)
+            {
+                query.Add("collection=" + Collection);
+            }
+            if (Type != null)
+            {
+                query.Add("type=" + Type);
+            }
+            if (WaitForSync != null)
+            {
+                query.Add("waitForSync=" + WaitForSync.ToString().ToLower());
+            }
+            if (Complete != null)
+            {
+                query.Add("complete=" + Complete.ToString().ToLower());
+            }
+            if (Details != null)
+            {
+                query.Add("details=" + Details.ToString().ToLower());
+            }
+            if (FromPrefix != null)
+            {
+                query.Add("fromPrefix=" + FromPrefix);
+            }
+            if (ToPrefix != null)
+            {
+                query.Add("toPrefix=" + ToPrefix);
+            }
+            if (Overwrite != null)
+            {
+                query.Add("overwrite=" + Overwrite.ToString().ToLower());
+            }
+            if (OnDuplicate != null)
+            {
+                query.Add("onDuplicate=" + Enum.GetName(typeof(ImportDocumentsOnDuplicate), OnDuplicate).ToString().ToLower());
+            }
+            return string.Join("&", query);
+        }
+    }
+}

--- a/arangodb-net-standard/BulkOperationsApi/Models/ImportDocumentsResponse.cs
+++ b/arangodb-net-standard/BulkOperationsApi/Models/ImportDocumentsResponse.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections.Generic;
+using System.Net;
+
+namespace ArangoDBNetStandard.BulkOperationsApi.Models
+{
+    public class ImportDocumentsResponse
+    {
+        /// <summary>
+        /// The number of documents imported.
+        /// </summary>
+        public int? Created { get; set; }
+
+        /// <summary>
+        /// The number of documents that were 
+        /// not imported due to an error.
+        /// </summary>
+        public int? Errors { get; set; }
+
+        /// <summary>
+        /// The number of empty lines found in the input 
+        /// (will only contain a value greater zero
+        /// for types documents or auto).
+        /// </summary>
+        public int? Empty { get; set; } 
+
+        /// <summary>
+        /// The number of updated/replaced documents
+        /// (in case onDuplicate was set to either
+        /// update or replace).
+        /// </summary>
+        public int? Updated { get; set; } 
+
+        /// <summary>
+        /// The number of failed but ignored
+        /// insert operations 
+        /// (in case onDuplicate was set to ignore).
+        /// </summary>
+        public int? Ignored { get; set; }
+
+        /// <summary>
+        /// If query parameter details is set to true,
+        /// this attribute is an array with more detailed
+        /// information about which documents could not
+        /// be inserted.
+        /// </summary>
+        public IList<string> Details { get; set; }
+
+        /// <summary>
+        /// The HTTP status code.
+        /// </summary>
+        public HttpStatusCode Code { get; set; }
+
+        /// <summary>
+        /// Indicates whether an error occurred
+        /// </summary>
+        public bool Error { get; set; }
+
+        /// <summary>
+        /// If Error occured, this is the Error Message
+        /// </summary>
+        public string ErrorMessage { get; set; }
+
+        /// <summary>
+        /// If Error occured, this is the Error Number
+        /// </summary>
+        public int? ErrorNum { get; set; }
+    }
+}

--- a/arangodb-net-standard/IArangoDBClient.cs
+++ b/arangodb-net-standard/IArangoDBClient.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using ArangoDBNetStandard.AqlFunctionApi;
 using ArangoDBNetStandard.AuthApi;
+using ArangoDBNetStandard.BulkOperationsApi;
 using ArangoDBNetStandard.CollectionApi;
 using ArangoDBNetStandard.CursorApi;
 using ArangoDBNetStandard.DatabaseApi;
@@ -63,5 +64,10 @@ namespace ArangoDBNetStandard
         /// Index management API.
         /// </summary>
         IndexApiClient Index { get; }
+
+        /// <summary>
+        /// Bulk Operations API.
+        /// </summary>
+        BulkOperationsApiClient BulkOperations { get; }
     }
 }

--- a/arangodb-net-standard/Serialization/ApiClientSerialization.cs
+++ b/arangodb-net-standard/Serialization/ApiClientSerialization.cs
@@ -33,5 +33,16 @@ namespace ArangoDBNetStandard.Serialization
         /// the serialization options should be provided by the serializer, otherwise the given options should be used.</param>
         /// <returns></returns>
         public abstract byte[] Serialize<T>(T item, ApiClientSerializationOptions serializationOptions);
+
+        /// <summary>
+        /// Serializes the specified object to a JSON string,
+        /// following the provided rules for camel case property name and null value handling.
+        /// </summary>
+        /// <typeparam name="T">The type of the object to serialize.</typeparam>
+        /// <param name="item">The object to serialize.</param>
+        /// <param name="serializationOptions">The serialization options. When the value is null the
+        /// the serialization options should be provided by the serializer, otherwise the given options should be used.</param>
+        /// <returns></returns>
+        public abstract string SerializeToString<T>(T item, ApiClientSerializationOptions serializationOptions);
     }
 }

--- a/arangodb-net-standard/Serialization/IApiClientSerialization.cs
+++ b/arangodb-net-standard/Serialization/IApiClientSerialization.cs
@@ -26,5 +26,16 @@ namespace ArangoDBNetStandard.Serialization
         /// the serialization options should be provided by the serializer, otherwise the given options should be used.</param>
         /// <returns></returns>
         byte[] Serialize<T>(T item, ApiClientSerializationOptions serializationOptions);
+
+        /// <summary>
+        /// Serializes the specified object to a JSON string,
+        /// following the provided rules for camel case property name and null value handling.
+        /// </summary>
+        /// <typeparam name="T">The type of the object to serialize.</typeparam>
+        /// <param name="item">The object to serialize.</param>
+        /// <param name="serializationOptions">The serialization options. When the value is null the
+        /// the serialization options should be provided by the serializer, otherwise the given options should be used.</param>
+        /// <returns></returns>
+        string SerializeToString<T>(T item, ApiClientSerializationOptions serializationOptions);
     }
 }

--- a/arangodb-net-standard/Serialization/JsonNetApiClientSerialization.cs
+++ b/arangodb-net-standard/Serialization/JsonNetApiClientSerialization.cs
@@ -47,6 +47,22 @@ namespace ArangoDBNetStandard.Serialization
 
         public override byte[] Serialize<T>(T item, ApiClientSerializationOptions serializationOptions)
         {
+            string json = SerializeToString(item, serializationOptions);
+            return Encoding.UTF8.GetBytes(json);
+        }
+
+
+        /// <summary>
+        /// Serializes an object to JSON string
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="item"></param>
+        /// <param name="serializationOptions">The serialization options. When the value is null the
+        /// the serialization options should be provided by the serializer, otherwise the given options should be used.</param>
+        /// <returns></returns>
+
+        public override string SerializeToString<T>(T item, ApiClientSerializationOptions serializationOptions)
+        {
             // When no options passed use the default.
             if (serializationOptions == null)
             {
@@ -71,7 +87,7 @@ namespace ArangoDBNetStandard.Serialization
 
             string json = JsonConvert.SerializeObject(item, jsonSettings);
 
-            return Encoding.UTF8.GetBytes(json);
+            return json;
         }
     }
 }

--- a/project/roadmap.md
+++ b/project/roadmap.md
@@ -173,3 +173,8 @@ A tick indicates an item is implemented and has automated tests in place.
 
 - [ ]	VelocyStream support
 - [ ]	VelocyPack-over-HTTP support
+
+#### Bulk Operations API
+
+- [X]	`POST /_api/import#document` Bulk Import Document Arrays
+- [X]	`POST /_api/import#json` Bulk Import Document Objects


### PR DESCRIPTION
Contains the following updates:
1) Adds support for bulk operations endpoints:
POST: /_api/import#document : imports document values
POST: /_api/import#json: imports documents from JSON

2) Roadmap doc - to reflect current state of development

3) Added SerializeToString() method to JsonNetApiClientSerialization.cs to support serializing an object to a simple JSON string. This is necessary because sometimes the bulk operations endpoints expects a non-standard JSON body (for example JSON objects or arrays separated by newline character). In such cases, it's necessary to serialize each object in the list and add them to the body separated by the new line character. We may change this in the future based on performance tests to identify the best way to deal with this.
