### PR TITLE
Support for analyzers

### DIFF
--- a/arangodb-net-standard.Test/AnalyzerApi/AnalyzerApiClientTest.cs
+++ b/arangodb-net-standard.Test/AnalyzerApi/AnalyzerApiClientTest.cs
@@ -1,0 +1,111 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using ArangoDBNetStandard;
+using ArangoDBNetStandard.AnalyzerApi;
+using ArangoDBNetStandard.AnalyzerApi.Models;
+using ArangoDBNetStandard.Transport;
+using Moq;
+using Xunit;
+
+namespace ArangoDBNetStandardTest.IndexApi
+{
+    public class AnalyzerApiClientTest : IClassFixture<AnalyzerApiClientTestFixture>, IAsyncLifetime
+    {
+        private AnalyzerApiClient _analyzerApi;
+        private ArangoDBClient _adb;
+
+        public AnalyzerApiClientTest(AnalyzerApiClientTestFixture fixture)
+        {
+            _adb = fixture.ArangoDBClient;
+            _analyzerApi = _adb.Analyzer;
+        }
+
+        public Task InitializeAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task DisposeAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        [Fact]
+        public async Task GetAllAnalyzersAsync_ShouldSucceed()
+        {
+            var res = await _analyzerApi.GetAllAnalyzersAsync();
+            Assert.Equal(HttpStatusCode.OK, res.Code);
+            Assert.False(res.Error);
+        }
+
+        [Fact]
+        public async Task PostAnalyzerAsync_ShouldSucceed()
+        {
+            var res = await _analyzerApi.PostAnalyzerAsync(
+                new Analyzer()
+                {
+                    Name = "text_sc",
+                    Type = "text",
+                    Properties = new AnalyzerProperties()
+                    {
+                        Accent = false,
+                        Case = "lower",
+                        Locale = "sc",
+                        Stemming = false,
+                        StopWords = new List<string>()
+                    },
+                    Features = new List<string>() 
+                    { 
+                        "frequency", 
+                        "position", 
+                        "norm" 
+                    }
+                }
+                );
+            Assert.NotNull(res);
+            Assert.NotNull(res.Name);
+        }
+
+        [Fact]
+        public async Task GetAnalyzerAsync_ShouldSucceed()
+        {
+            var allRes = await _analyzerApi.GetAllAnalyzersAsync();
+            var firstName = allRes.Result[0].Name;
+            var res = await _analyzerApi.GetAnalyzerAsync(firstName);
+            Assert.Equal(HttpStatusCode.OK, res.Code);
+            Assert.False(res.Error);
+        }
+
+        [Fact]
+        public async Task DeleteAnalyzerAsync_ShouldSucceed()
+        {
+            var name = "text_mu";
+            var createRes = await _analyzerApi.PostAnalyzerAsync(
+                new Analyzer()
+                {
+                    Name = name,
+                    Type = "text",
+                    Properties = new AnalyzerProperties()
+                    {
+                        Accent = false,
+                        Case = "lower",
+                        Locale = "mu",
+                        Stemming = false,
+                        StopWords = new List<string>()
+                    },
+                    Features = new List<string>()
+                    {
+                        "frequency",
+                        "position",
+                        "norm"
+                    }
+                }
+                );
+            var res = await _analyzerApi.DeleteAnalyzerAsync(name);
+            Assert.Equal(HttpStatusCode.OK, res.Code);
+            Assert.False(res.Error);
+        }
+    }
+}

--- a/arangodb-net-standard.Test/AnalyzerApi/AnalyzerApiClientTestFixture.cs
+++ b/arangodb-net-standard.Test/AnalyzerApi/AnalyzerApiClientTestFixture.cs
@@ -1,0 +1,44 @@
+﻿using ArangoDBNetStandard;
+using ArangoDBNetStandard.CollectionApi.Models;
+using ArangoDBNetStandard.AnalyzerApi.Models;
+using System;
+using System.Threading.Tasks;
+
+namespace ArangoDBNetStandardTest.IndexApi
+{
+    public class AnalyzerApiClientTestFixture : ApiClientTestFixtureBase
+    {
+        public ArangoDBClient ArangoDBClient { get; internal set; }
+
+        public AnalyzerApiClientTestFixture()
+        {
+        }
+
+        public override async Task InitializeAsync()
+        {
+            await base.InitializeAsync();
+
+            Console.WriteLine("AnalyzerApiClientTestFixture.InitializeAsync() started.");
+            string dbName = nameof(AnalyzerApiClientTestFixture);
+            await CreateDatabase(dbName);
+            Console.WriteLine("Database " + dbName + " created successfully");
+            ArangoDBClient = GetArangoDBClient(dbName);
+            try
+            {
+                var dbRes = await ArangoDBClient.Database.GetCurrentDatabaseInfoAsync();
+                if (dbRes.Error)
+                    throw new Exception("GetCurrentDatabaseInfoAsync failed: " + dbRes.Code.ToString());
+                else
+                {
+                    Console.WriteLine("In database " + dbRes.Result.Name);
+                }
+            }
+            catch (ApiErrorException ex) 
+            {
+                Console.WriteLine(ex.Message);
+                throw ex;
+            }
+
+        }
+    }
+}

--- a/arangodb-net-standard/AnalyzerApi/AnalyzerApiClient.cs
+++ b/arangodb-net-standard/AnalyzerApi/AnalyzerApiClient.cs
@@ -101,7 +101,7 @@ namespace ArangoDBNetStandard.AnalyzerApi
         {
             if (string.IsNullOrEmpty(analyzerName))
             {
-                throw new ArgumentException("analyzerName name is required", nameof(analyzerName));
+                throw new ArgumentException("Analyzer name is required", nameof(analyzerName));
             }
             string uri = _analyzerApiPath + '/' + WebUtility.UrlEncode(analyzerName);
             using (var response = await _client.GetAsync(uri).ConfigureAwait(false))
@@ -121,11 +121,11 @@ namespace ArangoDBNetStandard.AnalyzerApi
         /// </summary>
         /// <param name="analyzerName">The name of the analyzer</param>
         /// <returns></returns>
-        public virtual async Task<DeleteAnalyzerResponse> DeleteIndexAsync(string analyzerName)
+        public virtual async Task<DeleteAnalyzerResponse> DeleteAnalyzerAsync(string analyzerName)
         {
             if (string.IsNullOrEmpty(analyzerName))
             {
-                throw new ArgumentException("analyzerName name is required", nameof(analyzerName));
+                throw new ArgumentException("Analyzer name is required", nameof(analyzerName));
             }
             string uri = _analyzerApiPath + '/' + WebUtility.UrlEncode(analyzerName);
             using (var response = await _client.DeleteAsync(uri).ConfigureAwait(false))

--- a/arangodb-net-standard/AnalyzerApi/IAnalyzerApiClient.cs
+++ b/arangodb-net-standard/AnalyzerApi/IAnalyzerApiClient.cs
@@ -37,6 +37,6 @@ namespace ArangoDBNetStandard.AnalyzerApi
         /// </summary>
         /// <param name="analyzerName">The name of the analyzer</param>
         /// <returns></returns>
-        Task<DeleteAnalyzerResponse> DeleteIndexAsync(string analyzerName);
+        Task<DeleteAnalyzerResponse> DeleteAnalyzerAsync(string analyzerName);
     }
 }

--- a/arangodb-net-standard/AnalyzerApi/IAnalyzerApiClient.cs
+++ b/arangodb-net-standard/AnalyzerApi/IAnalyzerApiClient.cs
@@ -1,0 +1,42 @@
+﻿using ArangoDBNetStandard.AnalyzerApi.Models;
+using System.Threading.Tasks;
+
+namespace ArangoDBNetStandard.AnalyzerApi
+{
+    /// <summary>
+    /// Defines a client to access the ArangoDB Analyzer API.
+    /// </summary>
+    internal interface IAnalyzerApiClient
+    {
+        /// <summary>
+        /// Fetch the list of available Analyzer definitions.
+        /// GET /_api/analyzer
+        /// </summary>
+        /// <returns></returns>
+        Task<GetAllAnalyzersResponse> GetAllAnalyzersAsync();
+
+        /// <summary>
+        /// Creates a new Analyzer based on the provided definition
+        /// POST /_api/analyzer
+        /// </summary>
+        /// <param name="body">The properties of the new analyzer.</param>
+        /// <returns></returns>
+        Task<Analyzer> PostAnalyzerAsync(Analyzer body);
+
+        /// <summary>
+        /// Fetches the definition of the specified analyzer.
+        /// GET /_api/analyzer/{analyzer-name}
+        /// </summary>
+        /// <param name="analyzerName">The name of the analyzer</param>
+        /// <returns></returns>
+        Task<GetAnalyzerResponse> GetAnalyzerAsync(string analyzerName);
+
+        /// <summary>
+        /// Deletes an Analyzer.
+        /// DELETE /_api/analyzer/{analyzer-name}
+        /// </summary>
+        /// <param name="analyzerName">The name of the analyzer</param>
+        /// <returns></returns>
+        Task<DeleteAnalyzerResponse> DeleteIndexAsync(string analyzerName);
+    }
+}

--- a/arangodb-net-standard/AnalyzerApi/Models/Analyzer.cs
+++ b/arangodb-net-standard/AnalyzerApi/Models/Analyzer.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+
+namespace ArangoDBNetStandard.AnalyzerApi.Models
+{
+    public class Analyzer
+    {
+        public string Name { get; set; }
+        public string Type { get; set; }
+        public List<AnalyzerProperties> Properties { get; set; }
+        public List<string> Features { get; set; }
+    }
+
+}

--- a/arangodb-net-standard/AnalyzerApi/Models/Analyzer.cs
+++ b/arangodb-net-standard/AnalyzerApi/Models/Analyzer.cs
@@ -2,12 +2,31 @@
 
 namespace ArangoDBNetStandard.AnalyzerApi.Models
 {
+    /// <summary>
+    /// Defines an Analyzer in the database
+    /// </summary>
     public class Analyzer
     {
+        /// <summary>
+        /// Name of the analyzer
+        /// </summary>
         public string Name { get; set; }
+
+        /// <summary>
+        /// Type of the analyzer
+        /// </summary>
         public string Type { get; set; }
-        public List<AnalyzerProperties> Properties { get; set; }
+
+        /// <summary>
+        /// Properties of the analyzer
+        /// used to configure the specified type
+        /// </summary>
+        public AnalyzerProperties Properties { get; set; }
+
+        /// <summary>
+        /// The set of features to set on 
+        /// the Analyzer generated fields
+        /// </summary>
         public List<string> Features { get; set; }
     }
-
 }

--- a/arangodb-net-standard/AnalyzerApi/Models/AnalyzerProperties.cs
+++ b/arangodb-net-standard/AnalyzerApi/Models/AnalyzerProperties.cs
@@ -2,6 +2,9 @@
 
 namespace ArangoDBNetStandard.AnalyzerApi.Models
 {
+    /// <summary>
+    /// Properties of an Analyzer
+    /// </summary>
     public class AnalyzerProperties
     {
         public string Locale { get; set; }
@@ -10,5 +13,4 @@ namespace ArangoDBNetStandard.AnalyzerApi.Models
         public bool Accent { get; set; }
         public bool Stemming { get; set; }
     }
-
 }

--- a/arangodb-net-standard/AnalyzerApi/Models/AnalyzerProperties.cs
+++ b/arangodb-net-standard/AnalyzerApi/Models/AnalyzerProperties.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+
+namespace ArangoDBNetStandard.AnalyzerApi.Models
+{
+    public class AnalyzerProperties
+    {
+        public string Locale { get; set; }
+        public string Case { get; set; }
+        public List<string> StopWords { get; set; }
+        public bool Accent { get; set; }
+        public bool Stemming { get; set; }
+    }
+
+}

--- a/arangodb-net-standard/AnalyzerApi/Models/DeleteAnalyzerResponse.cs
+++ b/arangodb-net-standard/AnalyzerApi/Models/DeleteAnalyzerResponse.cs
@@ -1,0 +1,10 @@
+﻿namespace ArangoDBNetStandard.AnalyzerApi.Models
+{
+    /// <summary>
+    /// Represents a common response class for Analyzer API operations.
+    /// </summary>
+    public class DeleteAnalyzerResponse : ResponseBase
+    {
+        public string Name { get; set; }
+    }
+}

--- a/arangodb-net-standard/AnalyzerApi/Models/DeleteAnalyzerResponse.cs
+++ b/arangodb-net-standard/AnalyzerApi/Models/DeleteAnalyzerResponse.cs
@@ -1,7 +1,7 @@
 ﻿namespace ArangoDBNetStandard.AnalyzerApi.Models
 {
     /// <summary>
-    /// Represents a common response class for Analyzer API operations.
+    /// Response from <see cref="IAnalyzerApiClient.DeleteAnalyzerAsync(string)"/>
     /// </summary>
     public class DeleteAnalyzerResponse : ResponseBase
     {

--- a/arangodb-net-standard/AnalyzerApi/Models/GetAllAnalyzersResponse.cs
+++ b/arangodb-net-standard/AnalyzerApi/Models/GetAllAnalyzersResponse.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace ArangoDBNetStandard.AnalyzerApi.Models
+{
+    /// <summary>
+    /// Represents a common response class for Analyzer API operations.
+    /// </summary>
+    public class GetAllAnalyzersResponse : ResponseBase
+    {
+        public List<Analyzer> Result { get; set; }
+    }
+}

--- a/arangodb-net-standard/AnalyzerApi/Models/GetAllAnalyzersResponse.cs
+++ b/arangodb-net-standard/AnalyzerApi/Models/GetAllAnalyzersResponse.cs
@@ -3,10 +3,13 @@
 namespace ArangoDBNetStandard.AnalyzerApi.Models
 {
     /// <summary>
-    /// Represents a common response class for Analyzer API operations.
+    /// Response from <see cref="IAnalyzerApiClient.GetAllAnalyzersAsync"/>
     /// </summary>
     public class GetAllAnalyzersResponse : ResponseBase
     {
+        /// <summary>
+        /// List of analyzers
+        /// </summary>
         public List<Analyzer> Result { get; set; }
     }
 }

--- a/arangodb-net-standard/AnalyzerApi/Models/GetAnalyzerResponse.cs
+++ b/arangodb-net-standard/AnalyzerApi/Models/GetAnalyzerResponse.cs
@@ -3,7 +3,7 @@
 namespace ArangoDBNetStandard.AnalyzerApi.Models
 {
     /// <summary>
-    /// Represents a common response class for Analyzer API operations.
+    /// Response from <see cref="IAnalyzerApiClient.GetAnalyzerAsync(string)"/>
     /// </summary>
     public class GetAnalyzerResponse : Analyzer
     {

--- a/arangodb-net-standard/AnalyzerApi/Models/GetAnalyzerResponse.cs
+++ b/arangodb-net-standard/AnalyzerApi/Models/GetAnalyzerResponse.cs
@@ -1,0 +1,20 @@
+﻿using System.Net;
+
+namespace ArangoDBNetStandard.AnalyzerApi.Models
+{
+    /// <summary>
+    /// Represents a common response class for Analyzer API operations.
+    /// </summary>
+    public class GetAnalyzerResponse : Analyzer
+    {
+        /// <summary>
+        /// Indicates whether an error occurred
+        /// </summary>
+        public bool Error { get; set; }
+
+        /// <summary>
+        /// The HTTP status code.
+        /// </summary>
+        public HttpStatusCode Code { get; set; }
+    }
+}

--- a/arangodb-net-standard/AnalyzerApi/Models/ResponseBase.cs
+++ b/arangodb-net-standard/AnalyzerApi/Models/ResponseBase.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Net;
+using System.Text;
+
+namespace ArangoDBNetStandard.AnalyzerApi.Models
+{
+    /// <summary>
+    /// Represents a common response class for Analyzer API operations.
+    /// </summary>
+    public class ResponseBase
+    {
+        /// <summary>
+        /// Indicates whether an error occurred
+        /// </summary>
+        public bool Error { get; set; }
+
+        /// <summary>
+        /// The HTTP status code.
+        /// </summary>
+        public HttpStatusCode Code { get; set; }
+    }
+}

--- a/arangodb-net-standard/ArangoDBClient.cs
+++ b/arangodb-net-standard/ArangoDBClient.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using ArangoDBNetStandard.AnalyzerApi;
 using ArangoDBNetStandard.AqlFunctionApi;
 using ArangoDBNetStandard.AuthApi;
 using ArangoDBNetStandard.CollectionApi;
@@ -76,6 +77,11 @@ namespace ArangoDBNetStandard
         public IndexApiClient Index { get; private set; }
 
         /// <summary>
+        /// Index management API.
+        /// </summary>
+        public AnalyzerApiClient Analyzer { get; private set; }
+
+        /// <summary>
         /// Create an instance of <see cref="ArangoDBClient"/> from an existing
         /// <see cref="HttpClient"/> instance, using the default JSON serialization.
         /// </summary>
@@ -138,6 +144,7 @@ namespace ArangoDBNetStandard
             Graph = new GraphApiClient(transport, serialization);
             User = new UserApiClient(transport, serialization);
             Index = new IndexApiClient(transport, serialization);
+            Analyzer = new AnalyzerApiClient(transport, serialization); 
         }
     }
 }

--- a/arangodb-net-standard/IArangoDBClient.cs
+++ b/arangodb-net-standard/IArangoDBClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using ArangoDBNetStandard.AnalyzerApi;
 using ArangoDBNetStandard.AqlFunctionApi;
 using ArangoDBNetStandard.AuthApi;
 using ArangoDBNetStandard.CollectionApi;
@@ -63,5 +64,10 @@ namespace ArangoDBNetStandard
         /// Index management API.
         /// </summary>
         IndexApiClient Index { get; }
+
+        /// <summary>
+        /// Analyzer API.
+        /// </summary>
+        AnalyzerApiClient Analyzer { get; }
     }
 }


### PR DESCRIPTION
Added support for the Analyzers endpoints.
`GET /_api/analyzer` List all Analyzers
`POST /_api/analyzer Create an Analyzer` with the supplied definition
`DELETE /_api/analyzer/{analyzer-name}` Remove an Analyzer
`GET /_api/analyzer/{analyzer-name}` Return the Analyzer definition